### PR TITLE
Remove Rounding Up Decimal Values When Converting Json to Copybook

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "copybook"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ballerina"]
 keywords = ["copybook", "serdes", "cobol", "mainframe"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-copybook"
@@ -15,14 +15,14 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "copybook-native"
-version = "0.1.1-SNAPSHOT"
-path="../native/build/libs/copybook-native-0.1.1-SNAPSHOT.jar"
+version = "0.1.2-SNAPSHOT"
+path="../native/build/libs/copybook-native-0.1.2-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "copybook-commons"
-version = "0.1.1"
-path = "../commons/build/libs/copybook-commons-0.1.1-SNAPSHOT.jar"
+version = "0.1.2"
+path = "../commons/build/libs/copybook-commons-0.1.2-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.antlr"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "copybook"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ballerina"]
 keywords = ["copybook", "serdes", "cobol", "mainframe"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-copybook"
@@ -15,14 +15,14 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "copybook-native"
-version = "0.1.0"
-path="../native/build/libs/copybook-native-0.1.0.jar"
+version = "0.1.1-SNAPSHOT"
+path="../native/build/libs/copybook-native-0.1.1-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "copybook-commons"
-version = "0.1.0"
-path = "../commons/build/libs/copybook-commons-0.1.0.jar"
+version = "0.1.1"
+path = "../commons/build/libs/copybook-commons-0.1.1-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
 groupId = "org.antlr"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "copybook"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "copybook"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/tests/resources/copybook-json/copybook-9.json
+++ b/ballerina/tests/resources/copybook-json/copybook-9.json
@@ -1,0 +1,9 @@
+{
+    "Employee": {
+        "EmployeeId": 2.345234,
+        "ContractYears": 323.33,
+        "Salary": 0000005.200,
+        "Bonus": 003412.000000,
+        "APIT": 34567.6543
+    }
+}

--- a/ballerina/tests/resources/copybooks/copybook-9.cpy
+++ b/ballerina/tests/resources/copybooks/copybook-9.cpy
@@ -1,0 +1,6 @@
+01 Employee.
+   03 EmployeeId                   PIC 9(3).9.
+   03 ContractYears                PIC 9(2).999.
+   03 Salary                       PIC 9(6).99.
+   03 Bonus                        PIC 9(4).999.
+   03 APIT                        PIC 9(4).99.

--- a/ballerina/tests/resources/errors/copybook-9.json
+++ b/ballerina/tests/resources/errors/copybook-9.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    "Value '2.345234' exceeds the maximum number of fraction digits 1 at '$.Employee.EmployeeId'",
+    "Value '323.33' exceeds the maximum number of integer digits 2 at '$.Employee.ContractYears'",
+    "Value '34567.6543' exceeds the maximum number of integer digits 4 at '$.Employee.APIT'"
+  ]
+}

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -110,3 +110,16 @@ isolated function testToCopybookWithoutRedefinedItems() returns error? {
     string expectedAscii = check io:fileReadString(getInputPath("copybook-1"));
     test:assertEquals(asciiData, expectedAscii);
 }
+
+@test:Config
+isolated function testToCopybookReturningError() returns error? {
+    Convertor convertor = check new (getCopybookPath("copybook-9"));
+    json jsonInput = check io:fileReadJson(getCopybookJsonPath("copybook-9"));
+    string|Error copybook = convertor.toCopybook(check jsonInput.cloneWithType());
+    if copybook !is Error {
+        test:assertFail("Expected a 'copybook:Error' but found a 'string'");
+    }
+    json expectedErrorDetail = check getErrorDetail("copybook-9");
+    json actualErrorDetail = check copybook.detail().ensureType();
+    test:assertEquals(actualErrorDetail.toJson(), expectedErrorDetail);
+}

--- a/changelog.md
+++ b/changelog.md
@@ -5,3 +5,6 @@ This file contains all the notable changes done to the Ballerina Copybook packag
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- [[#5758] Remove Rounding Up Decimal Values when Converting Json to Copybook](https://github.com/ballerina-platform/ballerina-library/issues/5758)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=0.1.1-SNAPSHOT
+version=0.1.2-SNAPSHOT
 ballerinaLangVersion=2201.8.0
 
 checkstylePluginVersion=10.12.0


### PR DESCRIPTION
## Purpose

Fixes: [#5758](https://github.com/ballerina-platform/ballerina-library/issues/5758)

## Examples
N/A

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
